### PR TITLE
fixed variable typo in ccloud.auto.tfvars.example

### DIFF
--- a/terraform/gcp/ccloud.auto.tfvars.example
+++ b/terraform/gcp/ccloud.auto.tfvars.example
@@ -4,7 +4,7 @@
 
 src_bootstrap_server = "<CCLOUD_BOOTSTRAP_SERVER>"
 src_cluster_api_key = "<CCLOUD_API_KEY>"
-src_luster_api_secret = "<CCLOUD_API_SECRET>"
+src_cluster_api_secret = "<CCLOUD_API_SECRET>"
 
 dest_bootstrap_server = "<CCLOUD_BOOTSTRAP_SERVER>"
 dest_cluster_api_key = "<CCLOUD_API_KEY>"


### PR DESCRIPTION
was 'src_luster_api_secret' updated to 'src_cluster_api_secret' to match the replicator config.